### PR TITLE
Add service collector tests and docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,6 +97,11 @@ crypto.me-thirdweb/
     - If data is stale or missing for any service, it returns the available cached data (if any) and triggers an asynchronous background process.
     - The background process fetches updated data from individual `/api/services/*` endpoints and updates the `service_cache` table.
 
+#### Service Collectors (`src/pages/api/services/*.ts`)
+- **Purpose**: Each collector talks to a single upstream provider (ENS, Farcaster, XMTP, OpenSea, etc.) and writes normalized data into the `service_cache` table.
+- **Execution**: Collectors can run independently for debugging or as part of the `fast-profile` background refresh fan-out. They should remain fast and fail-soft so that slow upstreams don't block the page.
+- **Testing**: The `tests/service-collectors.test.ts` suite injects stubbed dependencies to assert that collectors return shaped data and surface configuration errors quickly without live API calls.
+
 #### Recent Profiles (`src/pages/api/recent-profiles.ts`)
 - **Purpose**: Retrieve recently updated profiles
 - **Endpoint**: `GET /api/recent-profiles`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Crypto.me Thirdweb is a central profile page for web3 identities. It allows users to view and manage their Ethereum Name Service (ENS) profiles, displaying the last error or the last successful sync time.
 
+The app aggregates data through **service collectors** (under `src/pages/api/services/*`). Each collector fetches data from a specific provider (ENS, Farcaster, XMTP, etc.) and augments the cached profile that powers `/api/fast-profile` and the profile UI. Collectors can be exercised individually, which helps us debug slow upstreams without running the full app.
+
 ## Tech Stack
 
 - [Next.js](https://nextjs.org): A React framework for building web applications.
@@ -43,6 +45,22 @@ yarn dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+### Running tests locally
+
+- Run the full collector smoke suite (uses stubbed network calls):
+
+```bash
+npm test
+```
+
+- Run a single collector test or test case by name:
+
+```bash
+npm test -- tests/service-collectors.test.ts --test-name-pattern "ENS"
+```
+
+These tests keep service collectors fast and deterministic by injecting stubbed dependencies instead of calling live third-party APIs.
 
 ## Database Setup and Maintenance
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "db:dev": "prisma db push",
     "db:migrate": "prisma migrate dev",
     "db:deploy": "prisma migrate deploy",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "TS_NODE_TRANSPILE_ONLY=1 node --test --require ./scripts/register-ts.js tests/**/*.test.ts"
   },
   "dependencies": {
     "@adraffy/ens-normalize": "^1.11.1",

--- a/scripts/register-ts.js
+++ b/scripts/register-ts.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const ts = require('typescript');
+
+function registerExtension(ext) {
+  require.extensions[ext] = function (module, filename) {
+    const source = fs.readFileSync(filename, 'utf8');
+    const { outputText } = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2020,
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.React,
+      },
+      fileName: filename,
+    });
+
+    return module._compile(outputText, filename);
+  };
+}
+
+registerExtension('.ts');
+registerExtension('.tsx');

--- a/tests/service-collectors.test.ts
+++ b/tests/service-collectors.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { createMocks } from 'node-mocks-http';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { createHandler as createEnsHandler } from '../src/pages/api/services/ens';
+import { createHandler as createFarcasterHandler } from '../src/pages/api/services/farcaster';
+
+const demoAddress = '0x1111111111111111111111111111111111111111';
+
+function mockResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('ENS service collector', () => {
+  it('resolves names and other records using injected dependencies', async () => {
+    const ensClientMock = {
+      getAddressRecord: async () => ({ value: demoAddress, id: 60 }),
+      getName: async () => ({ name: 'demo.eth' }),
+      getTextRecord: async () => null,
+    } as const;
+
+    const fetchFn = async () =>
+      mockResponse({ data: { domains: [{ name: 'demo.eth' }, { name: 'alt.eth' }] } });
+
+    const handler = createEnsHandler({ ensClient: ensClientMock, fetchFn });
+    const { req, res } = createMocks({ method: 'GET', query: { address: demoAddress } });
+
+    await handler(req as unknown as NextApiRequest, res as unknown as NextApiResponse);
+
+    assert.equal(res._getStatusCode(), 200);
+    const payload = res._getJSONData();
+    assert.equal(payload.primaryName, 'demo.eth');
+    assert.deepEqual(payload.otherNames, ['alt.eth']);
+    assert.ok(payload.profileUrl.includes('demo.eth'));
+  });
+
+  it('fails fast when address is missing', async () => {
+    const handler = createEnsHandler({
+      ensClient: {
+        getAddressRecord: async () => ({ value: demoAddress, id: 60 }),
+        getName: async () => null,
+        getTextRecord: async () => null,
+      } as const,
+      fetchFn: async () => mockResponse({ data: { domains: [] } }),
+    });
+
+    const { req, res } = createMocks({ method: 'GET', query: {} });
+    await handler(req as unknown as NextApiRequest, res as unknown as NextApiResponse);
+
+    assert.equal(res._getStatusCode(), 400);
+    assert.ok(res._getJSONData().error);
+  });
+});
+
+describe('Farcaster service collector', () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.NEYNAR_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.NEYNAR_API_KEY;
+    } else {
+      process.env.NEYNAR_API_KEY = originalKey;
+    }
+  });
+
+  it('returns a normalized Neynar payload for an address', async () => {
+    process.env.NEYNAR_API_KEY = 'test-key';
+
+    const fetchFn = async () =>
+      mockResponse({
+        [demoAddress.toLowerCase()]: [
+          {
+            username: 'collector',
+            display_name: 'Collector',
+            created_at: Date.now(),
+            follower_count: 12,
+            following_count: 4,
+            power_badge: true,
+            score: 0.9,
+            verified_addresses: { eth_addresses: [demoAddress] },
+          },
+        ],
+      });
+
+    const handler = createFarcasterHandler({
+      ensClient: {
+        getAddressRecord: async () => ({ value: demoAddress, id: 60 }),
+      } as const,
+      fetchFn,
+    });
+
+    const { req, res } = createMocks({ method: 'GET', query: { address: demoAddress } });
+    await handler(req as unknown as NextApiRequest, res as unknown as NextApiResponse);
+
+    assert.equal(res._getStatusCode(), 200);
+    const payload = res._getJSONData();
+    assert.equal(payload.username, 'collector');
+    assert.equal(payload.resolvedAddress, demoAddress);
+    assert.equal(payload.neynarScore, 0.9);
+    assert.ok(payload.followerCount >= 0);
+  });
+
+  it('surfaces a configuration error when the API key is missing', async () => {
+    delete process.env.NEYNAR_API_KEY;
+
+    const handler = createFarcasterHandler({
+      ensClient: {
+        getAddressRecord: async () => ({ value: demoAddress, id: 60 }),
+      } as const,
+      fetchFn: async () => mockResponse({}, 401),
+    });
+
+    const { req, res } = createMocks({ method: 'GET', query: { address: demoAddress } });
+    await handler(req as unknown as NextApiRequest, res as unknown as NextApiResponse);
+
+    assert.equal(res._getStatusCode(), 500);
+    assert.ok(res._getJSONData().error);
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency injection hooks to ENS and Farcaster collectors so they can be exercised with mocks
- introduce a node:test suite and lightweight TS register to validate collectors without live APIs
- document service collectors in the architecture and README with local test instructions

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2f6affbc8323a73f0c4a3317d78b)